### PR TITLE
Fixed help text that still referred to "schematics"

### DIFF
--- a/crates/bins/wasmflow/src/commands.rs
+++ b/crates/bins/wasmflow/src/commands.rs
@@ -27,13 +27,13 @@ pub(crate) enum CliCommand {
   /// Load a manifest and execute an entrypoint component (temporarily disabled).
   #[clap(name = "run", skip)]
   Run(run::RunCommand),
-  /// Load a manifest and run the default schematic.
+  /// Invoke a component from a manifest or wasm module.
   #[clap(name = "invoke")]
   Invoke(invoke::InvokeCommand),
-  /// Print the schematics and their accessible components for the passed manifest.
+  /// Print the components in a manifest or wasm module.
   #[clap(name = "list")]
   List(list::ListCommand),
-  /// Execute a schematic with test data and assert its output.
+  /// Execute a component with test data and assert its output.
   #[clap(name = "test")]
   Test(test::TestCommand),
 }

--- a/crates/bins/wasmflow/src/commands/invoke.rs
+++ b/crates/bins/wasmflow/src/commands/invoke.rs
@@ -62,7 +62,7 @@ pub(crate) struct InvokeCommand {
   #[clap(long = "seed", short = 's', env = "WAFL_SEED", action)]
   seed: Option<u64>,
 
-  /// Arguments to pass as inputs to a schematic.
+  /// Arguments to pass as inputs to a component.
   #[clap(last(true), action)]
   args: Vec<String>,
 }


### PR DESCRIPTION
This PR changes some of the help text wording to get rid of the term "schematics"