### PR TITLE
Improved error message for wafl rpc invoke, fixes #6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ crates/wasmflow-rpc/src/generated/wasmflow.rs
 crates/*/**/Cargo.lock
 bundle.tar
 /codegen/dist
+.vscode/*.log

--- a/crates/integration/test-wasi-component/Cargo.lock
+++ b/crates/integration/test-wasi-component/Cargo.lock
@@ -694,7 +694,7 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasmflow-boundary"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "wasmflow-codec",
@@ -704,7 +704,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-codec"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "rmp-serde",
  "serde",
@@ -715,7 +715,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-collection-link"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "tokio-stream",
@@ -728,7 +728,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-component"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "cfg-if",
  "serde",
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-entity"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "thiserror",
@@ -754,7 +754,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-interface"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "serde_repr",
@@ -763,7 +763,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-invocation"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "thiserror",
@@ -775,11 +775,11 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-macros"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 
 [[package]]
 name = "wasmflow-output"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "tokio-stream",
@@ -790,7 +790,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-packet"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "serde",
  "serde-value",
@@ -799,7 +799,7 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-sdk"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "futures",
  "wasmflow-boundary",
@@ -818,30 +818,28 @@ dependencies = [
 
 [[package]]
 name = "wasmflow-streams"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "futures",
  "pin-project-lite",
  "wasmflow-packet",
- "wasmflow-transport",
 ]
 
 [[package]]
 name = "wasmflow-traits"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "async-trait",
  "serde",
  "tokio",
  "tokio-stream",
- "tracing",
  "wasmflow-packet",
  "wasmflow-streams",
 ]
 
 [[package]]
 name = "wasmflow-transport"
-version = "0.9.0"
+version = "0.10.0-beta.4"
 dependencies = [
  "parking_lot",
  "serde",

--- a/crates/wasmflow/wasmflow-rpc/src/error.rs
+++ b/crates/wasmflow/wasmflow-rpc/src/error.rs
@@ -142,9 +142,17 @@ pub enum RpcClientError {
   #[error("I/O error: {0}")]
   IO(std::io::Error),
 
-  /// Error originating from Tonic GRPC server/client implementation
-  #[error("Tonic error: {0}")]
-  TonicError(tonic::transport::Error),
+  /// Error with Tls configuration
+  #[error("Tls error: {0}")]
+  TlsError(tonic::transport::Error),
+
+  /// Error connecting to service
+  #[error("{0}")]
+  ConnectionError(String),
+
+  /// Unspecified error connecting to service
+  #[error("unspecified connection error")]
+  UnspecifiedConnectionError,
 
   /// Connection failed
   #[error("Connection failed: {0}")]
@@ -158,11 +166,5 @@ pub enum RpcClientError {
 impl From<std::io::Error> for RpcClientError {
   fn from(e: std::io::Error) -> Self {
     RpcClientError::IO(e)
-  }
-}
-
-impl From<tonic::transport::Error> for RpcClientError {
-  fn from(e: tonic::transport::Error) -> Self {
-    RpcClientError::TonicError(e)
   }
 }


### PR DESCRIPTION
Exposed the inner source for a Tonic transport error to improve the error message on a failed connection