### PR TITLE
Removed assert in `wasmflow-rpc`'s build script.

### DIFF
--- a/crates/wasmflow/wasmflow-rpc/build.rs
+++ b/crates/wasmflow/wasmflow-rpc/build.rs
@@ -13,5 +13,9 @@ fn main() {
     .args(&["+nightly", "fmt", "--", "src/generated/wasmflow.rs"])
     .status()
     .expect("Failed to run cargo fmt on generated protobuf files.");
-  assert!(fmt.success(), "Can't format protobuf files");
+
+  if !fmt.success() {
+    // This can happen on minimally setup machines and is not a problem on its own.
+    println!("Could not format protobuf files");
+  }
 }


### PR DESCRIPTION
Machines without a comprehensive setup may fail to format the protobuf files and that shouldn't be a fatal error on its own. 

Unformatted files will fail tests and block PRs, but machines should still be able to build wasmflow regardless.