### PR TITLE
Developer experience improvements and bugfixes

### DIFF
--- a/codegen/templates/rust/partials/common/collection-signature.hbs
+++ b/codegen/templates/rust/partials/common/collection-signature.hbs
@@ -17,7 +17,7 @@ wasmflow_sdk::v1::types::CollectionSignature {
           name:"{{name}}".to_owned(),
           fields: std::collections::HashMap::from([
           {{#each fields}}
-            ("{{@key}}".to_owned(),{{> type-signature type}}),
+            ("{{@key}}".to_owned(),{{> type-signature .}}),
           {{/each}}
           ]).into()
         })

--- a/codegen/templates/rust/partials/common/type-signature.hbs
+++ b/codegen/templates/rust/partials/common/type-signature.hbs
@@ -16,6 +16,8 @@
   {{#case "raw"}}wasmflow_sdk::v1::types::TypeSignature::Raw{{/case}}
   {{#case "value"}}wasmflow_sdk::v1::types::TypeSignature::Value{{/case}}
 
+  {{#case "ref"}}wasmflow_sdk::v1::types::TypeSignature::Ref{ reference: "{{ref}}".to_owned() }{{/case}}
+
   {{#case "internal"}}
     wasmflow_sdk::v1::types::TypeSignature::Internal(
     {{#switch id }}
@@ -50,7 +52,7 @@
   {{/case}}
 
   {{#default}}
-    {{log .}}
+    {{log "Unknown type >>>" . "<<<"}}
     {{panic "Unknown type..."}}
   {{/default}}
 {{/switch}}

--- a/crates/wasmflow/wasmflow-sdk/crates/wasmflow-component/src/guest/wasm/exports.rs
+++ b/crates/wasmflow/wasmflow-sdk/crates/wasmflow-component/src/guest/wasm/exports.rs
@@ -48,9 +48,7 @@ pub(crate) extern "C" fn __async_guest_call(id: i32, op_len: i32, req_len: i32) 
   let dispatcher = dispatcher.unwrap();
 
   super::executor::spawn(async move {
-    println!(">> guest: in async task");
     let result = dispatcher.dispatch(op_str, slice).await;
-    println!(">> guest: operation result: {:?}", result);
     let code = match result {
       Ok(result) => {
         #[allow(unsafe_code)]

--- a/crates/wasmflow/wasmflow-test/src/lib.rs
+++ b/crates/wasmflow/wasmflow-test/src/lib.rs
@@ -91,7 +91,7 @@ use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use sdk::packet::PacketMap;
-use sdk::transport::{Failure, MessageTransport, Serialized, TransportWrapper};
+use sdk::transport::{Failure, MessageTransport, TransportWrapper};
 use sdk::{Entity, InherentData, Invocation};
 use serde::{Deserialize, Serialize};
 use tap::{TestBlock, TestRunner};
@@ -210,7 +210,7 @@ impl TestData {
     let mut payload = PacketMap::default();
     for (k, v) in &self.inputs {
       debug!("Test input for port '{}': {:?}", k, v);
-      payload.insert(k, MessageTransport::Success(Serialized::Struct(v.clone())));
+      payload.insert(k, &v);
     }
 
     if let Some(seed) = self.seed {
@@ -324,8 +324,8 @@ pub async fn run_test(
           format!("Expected: {:?}", expected_value),
         ]);
 
-        info!(i,j,actual=?actual_value, "actual");
-        info!(i,j,expected=?expected_value, "expected");
+        debug!(i,j,actual=?actual_value, "actual");
+        debug!(i,j,expected=?expected_value, "expected");
         test_block.add_test(
           move || match actual_value {
             Ok(val) => eq(val, expected_value),


### PR DESCRIPTION
This PR fixes some regressions from the wasmflow migration

- fixed codegen on custom types, fixes #59
- removed doubly wrapped inputs from test harness, fixes #60
- removed printlns from wasmflow-sdk, fixes #61