### PR TITLE
Aligning wasmflow and wafl CLI versions with the package version

### DIFF
--- a/crates/bins/wafl/src/commands.rs
+++ b/crates/bins/wafl/src/commands.rs
@@ -13,7 +13,6 @@ use clap::{AppSettings, Parser, Subcommand};
       global_setting(AppSettings::DeriveDisplayOrder),
       name = crate::BIN_NAME,
       about = crate::BIN_DESC,
-      version = option_env!("WAFL_VERSION").unwrap_or("0.0.0")
     )]
 pub(crate) struct Cli {
   #[clap(subcommand)]

--- a/crates/bins/wasmflow/src/commands.rs
+++ b/crates/bins/wasmflow/src/commands.rs
@@ -12,7 +12,6 @@ use logger::LoggingOptions;
   global_setting(AppSettings::DeriveDisplayOrder),
   name = crate::BIN_NAME,
   about = crate::BIN_DESC,
-  version = option_env!("WASMFLOW_VERSION").unwrap_or("0.0.0")
 )]
 pub(crate) struct Cli {
   #[clap(subcommand)]


### PR DESCRIPTION
The `wafl` and `wasmflow` binaries historically have had their CLI-reported versions defined by an ENV variable in the build process, but that's becoming less valuable with the new release process. This reverts the CLI versions back to package versions.