### PR TITLE
Added ability for `wafl query` to accept from STDIN

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1859,9 +1859,9 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "markup-converter"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46dd6e99e2c303d7f90636cfda8fd31d77864993b49b1cac35866647692cbc07"
+checksum = "045373ff68191b1f738bfa6cbe678719a12ab088baaed89e838c4fb0f70f56ae"
 dependencies = [
  "serde_json",
  "serde_yaml 0.9.4",

--- a/crates/bins/wafl/Cargo.toml
+++ b/crates/bins/wafl/Cargo.toml
@@ -37,7 +37,7 @@ oci-distribution = { version = "0.9", features = [
 ], default-features = false }
 wasmflow-oci = { path = "../../wasmflow/wasmflow-oci" }
 anyhow = "1.0"
-markup-converter = "0.1"
+markup-converter = "0.2"
 jaq-core = "0.7"
 
 [dev-dependencies]

--- a/crates/bins/wafl/src/commands/query.rs
+++ b/crates/bins/wafl/src/commands/query.rs
@@ -1,9 +1,11 @@
+use std::io::{self, BufRead};
 use std::path::PathBuf;
+use std::str::FromStr;
 
 use anyhow::Result;
 use clap::Args;
 use jaq_core::{parse, Ctx, Definitions, Val};
-use markup_converter::Transcoder;
+use markup_converter::{Format, Transcoder};
 
 #[derive(Debug, Clone, Args)]
 #[clap(rename_all = "kebab-case")]
@@ -15,18 +17,66 @@ pub(crate) struct Options {
   #[clap(short = 'r', long = "raw", action)]
   raw_output: bool,
 
+  /// Option to print raw output.
+  #[clap(short = 't', long = "type", action)]
+  kind: Option<MarkupKind>,
+
   /// Path to JSON, YAML, or TOML file.
-  #[clap(action)]
-  path: PathBuf,
+  #[clap(short = 'f', long = "file", action)]
+  path: Option<PathBuf>,
 
   /// The query.
   #[clap(action)]
   query: String,
 }
 
+#[derive(Debug, Clone)]
+enum MarkupKind {
+  Json,
+  Toml,
+  Yaml,
+}
+
+impl FromStr for MarkupKind {
+  type Err = anyhow::Error;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "json" => Ok(MarkupKind::Json),
+      "toml" => Ok(MarkupKind::Toml),
+      "yaml" => Ok(MarkupKind::Yaml),
+      _ => Err(anyhow!("Markup kind '{}' not supported", s)),
+    }
+  }
+}
+
 #[allow(clippy::unused_async)]
 pub(crate) async fn handle(opts: Options) -> Result<()> {
-  let input = Transcoder::new(&opts.path)?.to_json()?;
+  let input = if let Some(path) = opts.path {
+    match opts.kind {
+      None => Transcoder::from_path(&path)?.to_json()?,
+      Some(kind) => {
+        let source = crate::io::read_to_string(&path).await?;
+        match kind {
+          MarkupKind::Json => Transcoder::new(Format::json(&source)?)?.to_json()?,
+          MarkupKind::Toml => Transcoder::new(Format::toml(&source)?)?.to_json()?,
+          MarkupKind::Yaml => Transcoder::new(Format::yaml(&source)?)?.to_json()?,
+        }
+      }
+    }
+  } else {
+    if atty::is(atty::Stream::Stdin) {
+      eprintln!("No file path passed, reading from <STDIN>. Use -f/--file to pass a file as an argument.");
+    }
+    let reader = io::BufReader::new(io::stdin());
+    let lines = reader.lines();
+    let markup = lines.collect::<Result<String, _>>()?;
+    match opts.kind {
+      Some(MarkupKind::Json) | None => Transcoder::new(Format::json(&markup)?)?.to_json()?,
+      Some(MarkupKind::Toml) => Transcoder::new(Format::toml(&markup)?)?.to_json()?,
+      Some(MarkupKind::Yaml) => Transcoder::new(Format::yaml(&markup)?)?.to_json()?,
+    }
+  };
 
   let filter = &opts.query;
 

--- a/crates/bins/wafl/tests/cmd/query/_sample.json
+++ b/crates/bins/wafl/tests/cmd/query/_sample.json
@@ -1,0 +1,21 @@
+{
+  "name": "test-data",
+  "version": "0.0.0",
+  "description": "Wasmflow internal scripts",
+  "directories": {
+    "example": "examples",
+    "test": "tests"
+  },
+  "scripts": {
+    "update-lint": "ts-node ./scripts/update-lints.ts"
+  },
+  "dependencies": {
+    "@types/node": "^16.0.0",
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.5"
+  },
+  "devDependencies": {},
+  "author": "",
+  "license": "ISC",
+  "main": "index.js"
+}

--- a/crates/bins/wafl/tests/cmd/query/_sample.random
+++ b/crates/bins/wafl/tests/cmd/query/_sample.random
@@ -1,0 +1,57 @@
+name: test-data
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 8080 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: wasmflow_service
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
+                      cors:
+                        allow_origin_string_match:
+                          - prefix: "*"
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: "1728000"
+                        expose_headers: custom-header-1,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: wasmflow_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: cluster_0
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.docker.internal
+                      port_value: 8060

--- a/crates/bins/wafl/tests/cmd/query/_sample.yaml
+++ b/crates/bins/wafl/tests/cmd/query/_sample.yaml
@@ -1,0 +1,57 @@
+name: test-data
+static_resources:
+  listeners:
+    - name: listener_0
+      address:
+        socket_address: { address: 0.0.0.0, port_value: 8080 }
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                codec_type: auto
+                stat_prefix: ingress_http
+                route_config:
+                  name: local_route
+                  virtual_hosts:
+                    - name: local_service
+                      domains: ["*"]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            cluster: wasmflow_service
+                            timeout: 0s
+                            max_stream_duration:
+                              grpc_timeout_header_max: 0s
+                      cors:
+                        allow_origin_string_match:
+                          - prefix: "*"
+                        allow_methods: GET, PUT, DELETE, POST, OPTIONS
+                        allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,grpc-timeout
+                        max_age: "1728000"
+                        expose_headers: custom-header-1,grpc-status,grpc-message
+                http_filters:
+                  - name: envoy.filters.http.grpc_web
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.grpc_web.v3.GrpcWeb
+                  - name: envoy.filters.http.cors
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.cors.v3.Cors
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+  clusters:
+    - name: wasmflow_service
+      connect_timeout: 0.25s
+      type: logical_dns
+      http2_protocol_options: {}
+      lb_policy: round_robin
+      load_assignment:
+        cluster_name: cluster_0
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: host.docker.internal
+                      port_value: 8060

--- a/crates/bins/wafl/tests/cmd/query/json-raw.toml
+++ b/crates/bins/wafl/tests/cmd/query/json-raw.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -r -f tests/cmd/query/_sample.json .name"
+stdout = "test-data\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/json-stdin.toml
+++ b/crates/bins/wafl/tests/cmd/query/json-stdin.toml
@@ -1,0 +1,5 @@
+bin.name = "wafl"
+args = "query .name"
+stdin = "{\"name\":\"test-data\"}"
+stdout = "\"test-data\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/json.toml
+++ b/crates/bins/wafl/tests/cmd/query/json.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -f tests/cmd/query/_sample.json .name"
+stdout = "\"test-data\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/random.toml
+++ b/crates/bins/wafl/tests/cmd/query/random.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -f tests/cmd/query/_sample.random -t yaml .name"
+stdout = "\"test-data\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/raw-toml.toml
+++ b/crates/bins/wafl/tests/cmd/query/raw-toml.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -r -f Cargo.toml .package.name"
+stdout = "wafl\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/toml.toml
+++ b/crates/bins/wafl/tests/cmd/query/toml.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -f Cargo.toml .package.name"
+stdout = "\"wafl\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/yaml-stdin.toml
+++ b/crates/bins/wafl/tests/cmd/query/yaml-stdin.toml
@@ -1,0 +1,5 @@
+bin.name = "wafl"
+args = "query -t yaml .name"
+stdin = "name: test-data\n"
+stdout = "\"test-data\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/cmd/query/yaml.toml
+++ b/crates/bins/wafl/tests/cmd/query/yaml.toml
@@ -1,0 +1,4 @@
+bin.name = "wafl"
+args = "query -f tests/cmd/query/_sample.yaml .name"
+stdout = "\"test-data\"\n"
+name = "wat"

--- a/crates/bins/wafl/tests/run.rs
+++ b/crates/bins/wafl/tests/run.rs
@@ -1,4 +1,4 @@
-#[tokio::test]
-async fn wafl_invoke() {
-  tracing::warn!("TODO");
+#[test]
+fn cli_tests() {
+  trycmd::TestCases::new().case("tests/cmd/**/*.toml");
 }

--- a/crates/misc/tap/src/lib.rs
+++ b/crates/misc/tap/src/lib.rs
@@ -130,9 +130,8 @@ impl TestRunner {
       total_tests += block.num_tests();
     }
 
-    let name = format!("# {}", description);
-    let plan_line = format!("1..{}", total_tests);
-    let mut all_lines = vec![name, plan_line];
+    let plan_line = format!("1..{} # {}", total_tests, description);
+    let mut all_lines = vec![plan_line];
 
     let mut test_num = 0;
     for block in self.blocks.iter_mut() {

--- a/crates/misc/tap/tests/basic.rs
+++ b/crates/misc/tap/tests/basic.rs
@@ -19,8 +19,7 @@ fn basics() -> anyhow::Result<()> {
   runner.run();
 
   let expected = vec![
-    "# My test",
-    "1..2",
+    "1..2 # My test",
     "# My block",
     "ok 1 three is greater than two",
     "not ok 2 three is less than two",


### PR DESCRIPTION
This PR modifies `wafl query` to support accepting input from STDIN and specifying a type for the passed markup. I also added some `wafl` tests with trycmd.