### PR TITLE
Added "version" config for CLAP to re-enable --version flag

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.60"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794e162a5eff65c72ef524dfe393eb923c354e350bb78b9c7383df13f3bc142"
+checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
 name = "async-channel"
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.10.0"
+version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
+checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
 
 [[package]]
 name = "byteorder"
@@ -401,9 +401,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f725f340c3854e3cb3ab736dc21f0cca183303acea3b3ffec30f141503ac8eb"
+checksum = "bfd4d1b31faaa3a89d7934dbded3111da0d2ef28e3ebccdb4f0179f5929d1ef1"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -437,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.2.16"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3dbbb6653e7c55cc8595ad3e1f7be8f32aba4eb7ff7f0fd1163d4f3d137c0a9"
+checksum = "b15f2ea93df33549dbe2e8eecd1ca55269d63ae0b3ba1f55db030817d1c2867f"
 dependencies = [
  "atty",
  "bitflags",
@@ -454,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.2.15"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba52acd3b0a5c33aeada5cdaa3267cdc7c594a98731d4268cdc1532f4264cb4"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -505,7 +505,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
 ]
 
 [[package]]
@@ -598,9 +598,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "dc948ebb96241bb40ab73effeb80d9f93afaad49359d159a5e61be51619fe813"
 dependencies = [
  "libc",
 ]
@@ -959,12 +959,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dtoa"
-version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
-
-[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"
@@ -1152,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1167,9 +1161,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1177,15 +1171,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1194,9 +1188,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-lite"
@@ -1215,9 +1209,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1226,21 +1220,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1339,9 +1333,9 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
+checksum = "5ca32592cf21ac7ccab1825cd87f6c9b3d9022c44d086172ed0966bec8af30be"
 dependencies = [
  "bytes",
  "fnv",
@@ -1352,7 +1346,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tracing",
 ]
 
@@ -1547,12 +1541,12 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.41"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1779539f58004e5dba1c1f093d44325ebeb244bfc04b791acdc0aaeca9c04570"
+checksum = "ad2bfd338099682614d3ee3fe0cd72e0b6a41ca6a87f6a74a3bd593c91650501"
 dependencies = [
  "android_system_properties",
- "core-foundation",
+ "core-foundation-sys",
  "js-sys",
  "wasm-bindgen",
  "winapi",
@@ -1612,9 +1606,9 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c3f4eff5495aee4c0399d7b6a0dc2b6e81be84242ffbfcf253ebacccc1d0cb"
+checksum = "1ea37f355c05dde75b84bba2d767906ad522e97cd9e2eef2be7a4ab7fb442c06"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1750,9 +1744,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.129"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64de3cc433455c14174d42e554d4027ee631c4d046d43e3ecc6efc4636cdc7a7"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
 
 [[package]]
 name = "libgit2-sys"
@@ -1808,9 +1802,9 @@ checksum = "d4d2456c373231a208ad294c33dc5bff30051eafd954cd4caae83a712b12854d"
 
 [[package]]
 name = "lock_api"
-version = "0.4.7"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
+checksum = "9f80bf5aacaf25cbfc8210d1cfb718f2bf3b11c4c54e5afe36c236853a8ec390"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -1830,10 +1824,10 @@ name = "logger"
 version = "0.1.0"
 dependencies = [
  "ansi_term",
- "clap 3.2.16",
+ "clap 3.2.18",
  "serde",
  "thiserror",
- "time 0.3.13",
+ "time 0.3.14",
  "tracing",
  "tracing-appender",
  "tracing-bunyan-formatter",
@@ -1864,7 +1858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "045373ff68191b1f738bfa6cbe678719a12ab088baaed89e838c4fb0f70f56ae"
 dependencies = [
  "serde_json",
- "serde_yaml 0.9.4",
+ "serde_yaml 0.9.10",
  "thiserror",
  "toml",
 ]
@@ -2148,9 +2142,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "oorandom"
@@ -2240,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "os_str_bytes"
-version = "6.2.0"
+version = "6.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "output_vt100"
@@ -2367,18 +2361,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2417,9 +2411,9 @@ checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
 
 [[package]]
 name = "plotters"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9428003b84df1496fb9d6eeee9c5f8145cb41ca375eb0dad204328888832811f"
+checksum = "716b4eeb6c4a1d3ecc956f75b43ec2e8e8ba80026413e70a3f41fd3313d3492b"
 dependencies = [
  "num-traits",
  "plotters-backend",
@@ -2436,9 +2430,9 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -2691,21 +2685,21 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.21.5"
+version = "0.21.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
+checksum = "571c252c68d09a2ad3e49edd14e9ee48932f3e0f27b06b4ea4c9b2a706d31103"
 dependencies = [
  "async-trait",
  "bytes",
  "combine",
- "dtoa",
  "futures-util",
- "itoa 0.4.8",
+ "itoa 1.0.3",
  "percent-encoding 2.1.0",
  "pin-project-lite",
+ "ryu",
  "sha1",
  "tokio",
- "tokio-util 0.6.10",
+ "tokio-util",
  "url 2.2.2",
 ]
 
@@ -2821,7 +2815,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tower-service",
  "url 2.2.2",
  "wasm-bindgen",
@@ -2889,9 +2883,9 @@ checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustix"
-version = "0.35.7"
+version = "0.35.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51cc38aa10f6bbb377ed28197aa052aa4e2b762c22be9d3153d01822587e787"
+checksum = "72c825b8aa8010eb9ee99b75f05e10180b9278d161583034d7574c9d617aeada"
 dependencies = [
  "bitflags",
  "errno",
@@ -3021,9 +3015,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -3054,9 +3048,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
+checksum = "0f747710de3dcd43b88c9168773254e809d8ddbdf9653b84e2554ab219f17860"
 dependencies = [
  "serde_derive",
 ]
@@ -3093,9 +3087,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.143"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
+checksum = "94ed3a816fb1d101812f83e789f888322c34e291f894f19590dc310963e87a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3104,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "e55a28e3aaef9d5ce0506d0a14dbba8054ddc7e499ef522dd8b26859ec9d4a44"
 dependencies = [
  "itoa 1.0.3",
  "ryu",
@@ -3150,9 +3144,9 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.9.4"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b7c9017c64a49806c6e8df8ef99b92446d09c92457f85f91835b01a8064ae0"
+checksum = "7a09f551ccc8210268ef848f0bab37b306e87b85b2e017b899e7fb815f5aed62"
 dependencies = [
  "indexmap",
  "itoa 1.0.3",
@@ -3248,9 +3242,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f054c6c1a6e95179d6f23ed974060dcefb2d9388bb7256900badad682c499de4"
+checksum = "f0ea32af43239f0d353a7dd75a22d94c329c8cdaafdcb4c1c1335aa10c298a4a"
 
 [[package]]
 name = "similar"
@@ -3281,9 +3275,9 @@ checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
 name = "snapbox"
-version = "0.3.1"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f6603988128836d0ed032a28fac5fb049958e21578e9aed2ed05f69bb562a"
+checksum = "44d199ccf8f606592df2d145db26f2aa45344e23c64b074cc5a4047f1d99b0f7"
 dependencies = [
  "concolor",
  "content_inspector",
@@ -3307,9 +3301,9 @@ checksum = "8a253e6f894cfa440cba00600a249fa90869d8e0ec45ab274a456e043a0ce8f2"
 
 [[package]]
 name = "socket2"
-version = "0.4.4"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+checksum = "10c98bba371b9b22a71a9414e420f92ddeb2369239af08200816169d5e2dd7aa"
 dependencies = [
  "libc",
  "winapi",
@@ -3513,7 +3507,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.2.16",
+ "clap 3.2.18",
  "futures",
  "logger",
  "pretty_assertions",
@@ -3594,9 +3588,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
 dependencies = [
  "itoa 1.0.3",
  "libc",
@@ -3723,20 +3717,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
@@ -3796,7 +3776,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-stream",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
@@ -3846,7 +3826,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -3903,7 +3883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d48f71a791638519505cefafe162606f706c25592e4bde4d97600c0195312e"
 dependencies = [
  "crossbeam-channel",
- "time 0.3.13",
+ "time 0.3.14",
  "tracing-subscriber",
 ]
 
@@ -3928,7 +3908,7 @@ dependencies = [
  "log",
  "serde",
  "serde_json",
- "time 0.3.13",
+ "time 0.3.14",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -3991,7 +3971,7 @@ dependencies = [
  "sharded-slab",
  "smallvec",
  "thread_local",
- "time 0.3.13",
+ "time 0.3.14",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -4006,9 +3986,9 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "trycmd"
-version = "0.13.5"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a09d4fff814904dc04bf60dc19fd7ed41715e3e00dd423eb1c5636a942e2a4"
+checksum = "9ac9fa73959e252e7c5a4e6260544b952f5bf3989e0b7ad229f4fd6f14671b02"
 dependencies = [
  "glob",
  "humantime",
@@ -4167,12 +4147,12 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wafl"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-recursion",
  "atty",
- "clap 3.2.16",
+ "clap 3.2.18",
  "cli-common",
  "git2",
  "jaq-core",
@@ -4404,9 +4384,9 @@ checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8905fd25fdadeb0e7e8bf43a9f46f9f972d6291ad0c7a32573b88dd13a6cfa6b"
+checksum = "d443c5a7daae71697d97ec12ad70b4fe8766d3a0f4db16158ac8b781365892f7"
 dependencies = [
  "leb128",
 ]
@@ -4417,7 +4397,7 @@ version = "0.4.1"
 dependencies = [
  "anyhow",
  "atty",
- "clap 3.2.16",
+ "clap 3.2.18",
  "cli-common",
  "logger",
  "nkeys 0.2.0",
@@ -4468,7 +4448,7 @@ dependencies = [
  "anyhow",
  "async-stream",
  "cfg-if",
- "clap 3.2.16",
+ "clap 3.2.18",
  "logger",
  "once_cell",
  "reqwest",
@@ -4634,7 +4614,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
- "clap 3.2.16",
+ "clap 3.2.18",
  "env_logger 0.9.0",
  "logger",
  "serde",
@@ -4764,7 +4744,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "clap 3.2.16",
+ "clap 3.2.18",
  "futures",
  "logger",
  "once_cell",
@@ -4775,7 +4755,7 @@ dependencies = [
  "test-logger",
  "thiserror",
  "tokio",
- "tokio-util 0.7.3",
+ "tokio-util",
  "tonic",
  "tracing",
  "tracing-futures",
@@ -4850,7 +4830,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-recursion",
- "clap 3.2.16",
+ "clap 3.2.18",
  "env_logger 0.9.0",
  "logger",
  "oci-distribution",
@@ -5341,9 +5321,9 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "45.0.0"
+version = "46.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "186c474c4f9bb92756b566d592a16591b4526b1a4841171caa3f31d7fe330d96"
+checksum = "ea0ab19660e3ea6891bba69167b9be40fad00fb1fe3dd39c5eebcee15607131b"
 dependencies = [
  "leb128",
  "memchr",
@@ -5353,11 +5333,11 @@ dependencies = [
 
 [[package]]
 name = "wat"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d4bc4724b4f02a482c8cab053dac5ef26410f264c06ce914958f9a42813556"
+checksum = "8f775282def4d5bffd94d60d6ecd57bfe6faa46171cdbf8d32bd5458842b1e3e"
 dependencies = [
- "wast 45.0.0",
+ "wast 46.0.0",
 ]
 
 [[package]]

--- a/crates/bins/cli-common/src/lib.rs
+++ b/crates/bins/cli-common/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/bins/wafl/src/commands.rs
+++ b/crates/bins/wafl/src/commands.rs
@@ -14,6 +14,7 @@ use clap::{AppSettings, Parser, Subcommand};
       global_setting(AppSettings::DeriveDisplayOrder),
       name = crate::BIN_NAME,
       about = crate::BIN_DESC,
+      version,
     )]
 pub(crate) struct Cli {
   #[clap(subcommand)]

--- a/crates/bins/wafl/src/main.rs
+++ b/crates/bins/wafl/src/main.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs, clippy::expect_used)]

--- a/crates/bins/wasmflow/src/commands.rs
+++ b/crates/bins/wasmflow/src/commands.rs
@@ -12,6 +12,7 @@ use logger::LoggingOptions;
   global_setting(AppSettings::DeriveDisplayOrder),
   name = crate::BIN_NAME,
   about = crate::BIN_DESC,
+  version,
 )]
 pub(crate) struct Cli {
   #[clap(subcommand)]

--- a/crates/bins/wasmflow/src/main.rs
+++ b/crates/bins/wasmflow/src/main.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 

--- a/crates/collections/collection-keyvalue-redis/src/lib.rs
+++ b/crates/collections/collection-keyvalue-redis/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/collections/collection-keyvalue-redis/src/main.rs
+++ b/crates/collections/collection-keyvalue-redis/src/main.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(clippy::expect_used, missing_docs)]

--- a/crates/interfaces/wasmflow-interface-keyvalue/src/lib.rs
+++ b/crates/interfaces/wasmflow-interface-keyvalue/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/misc/performance-mark/src/lib.rs
+++ b/crates/misc/performance-mark/src/lib.rs
@@ -3,6 +3,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -81,7 +82,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/misc/seeded-random/src/lib.rs
+++ b/crates/misc/seeded-random/src/lib.rs
@@ -3,6 +3,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -81,7 +82,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(clippy::must_use_candidate)]

--- a/crates/misc/tap/src/lib.rs
+++ b/crates/misc/tap/src/lib.rs
@@ -3,6 +3,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -81,7 +82,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/misc/tokio-test-bin/src/lib.rs
+++ b/crates/misc/tokio-test-bin/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(clippy::expect_used)]

--- a/crates/misc/workspace-root/src/lib.rs
+++ b/crates/misc/workspace-root/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/logger/src/lib.rs
+++ b/crates/wasmflow/logger/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-collection-cli/src/lib.rs
+++ b/crates/wasmflow/wasmflow-collection-cli/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-collection-grpc/src/lib.rs
+++ b/crates/wasmflow/wasmflow-collection-grpc/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-collection-grpctar/src/lib.rs
+++ b/crates/wasmflow/wasmflow-collection-grpctar/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-collection-nats/src/lib.rs
+++ b/crates/wasmflow/wasmflow-collection-nats/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-collection-wasm/src/lib.rs
+++ b/crates/wasmflow/wasmflow-collection-wasm/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-grpctar/src/archive.rs
+++ b/crates/wasmflow/wasmflow-grpctar/src/archive.rs
@@ -32,7 +32,7 @@ pub fn make_archive<T: Read>(
   debug!(?claims, "oci archive claims");
   let mut bin_bytes = Vec::new();
   binary.read_to_end(&mut bin_bytes)?;
-  let combined_bytes = bin_bytes.chain(&*signature_bytes);
+  let combined_bytes = bin_bytes.chain(signature_bytes);
   let jwt_bytes = wasmflow_wascap::make_jwt(combined_bytes, &claims, issuer_kp)?;
   let mut jwt_header = Header::new_gnu();
   jwt_header.set_path("archive.jwt")?;

--- a/crates/wasmflow/wasmflow-grpctar/src/lib.rs
+++ b/crates/wasmflow/wasmflow-grpctar/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-host/src/lib.rs
+++ b/crates/wasmflow/wasmflow-host/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-interpreter/src/interpreter/collections/internal_collection.rs
+++ b/crates/wasmflow/wasmflow-interpreter/src/interpreter/collections/internal_collection.rs
@@ -40,7 +40,7 @@ impl Collection for InternalCollection {
 
     let is_oneshot = op == SCHEMATIC_INPUT || op == INTERNAL_ID_INHERENT;
     let task = async move {
-      let result = if op == SCHEMATIC_OUTPUT {
+      if op == SCHEMATIC_OUTPUT {
         panic!("Output component should not be executed");
       } else if is_oneshot {
         oneshot::OneShotComponent::default()
@@ -48,8 +48,7 @@ impl Collection for InternalCollection {
           .await
       } else {
         panic!("Internal component {} not handled.", op);
-      };
-      result
+      }
     };
     Box::pin(task)
   }

--- a/crates/wasmflow/wasmflow-interpreter/src/lib.rs
+++ b/crates/wasmflow/wasmflow-interpreter/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-invocation-server/src/lib.rs
+++ b/crates/wasmflow/wasmflow-invocation-server/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-loader/src/lib.rs
+++ b/crates/wasmflow/wasmflow-loader/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-manifest/src/lib.rs
+++ b/crates/wasmflow/wasmflow-manifest/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-mesh/src/lib.rs
+++ b/crates/wasmflow/wasmflow-mesh/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-mesh/src/mesh.rs
+++ b/crates/wasmflow/wasmflow-mesh/src/mesh.rs
@@ -260,7 +260,7 @@ impl Mesh {
     let payload = serialize(&msg).map_err(|e| MeshError::MessageSerialization(e.to_string()))?;
     let sub = self.nats.request(&topic, &payload).await?;
 
-    let components = match sub.next().await? {
+    match sub.next().await? {
       Some(mesh_msg) => match mesh_msg.deserialize::<MeshRpcResponse>() {
         Ok(MeshRpcResponse::List(list)) => Ok(list),
         Ok(MeshRpcResponse::Error(e)) => Err(MeshError::ListFail(e)),
@@ -268,9 +268,7 @@ impl Mesh {
         _ => unreachable!(),
       },
       None => Ok(vec![]),
-    };
-
-    components
+    }
   }
 }
 

--- a/crates/wasmflow/wasmflow-oci/src/lib.rs
+++ b/crates/wasmflow/wasmflow-oci/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-parser/src/lib.rs
+++ b/crates/wasmflow/wasmflow-parser/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-rpc/src/lib.rs
+++ b/crates/wasmflow/wasmflow-rpc/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-runtime/src/lib.rs
+++ b/crates/wasmflow/wasmflow-runtime/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)] // TODO

--- a/crates/wasmflow/wasmflow-schematic-graph/src/lib.rs
+++ b/crates/wasmflow/wasmflow-schematic-graph/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-sdk/src/lib.rs
+++ b/crates/wasmflow/wasmflow-sdk/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]

--- a/crates/wasmflow/wasmflow-stdlib/src/lib.rs
+++ b/crates/wasmflow/wasmflow-stdlib/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-test/src/lib.rs
+++ b/crates/wasmflow/wasmflow-test/src/lib.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(missing_docs)]

--- a/crates/wasmflow/wasmflow-wascap/src/lib.rs
+++ b/crates/wasmflow/wasmflow-wascap/src/lib.rs
@@ -4,6 +4,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -82,7 +83,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow(unused)]

--- a/etc/lints.rs
+++ b/etc/lints.rs
@@ -2,6 +2,7 @@
 // Wasmflow lints
 // Do not change anything between the START_LINTS and END_LINTS line.
 // This is automatically generated. Add exceptions after this section.
+#![allow(unknown_lints)]
 #![deny(
   clippy::expect_used,
   clippy::explicit_deref_methods,
@@ -80,7 +81,7 @@
   while_true,
   missing_docs
 )]
-#![allow(unused_attributes)]
+#![allow(unused_attributes, clippy::derive_partial_eq_without_eq)]
 // !!END_LINTS
 // Add exceptions here
 #![allow()]


### PR DESCRIPTION
Removing the `ENV`-derived version configuration apparently removes any automatic version support in CLAP executables.

This PR adds (re-adds) a basic `version` config that pulls the version from the package version.