### PR TITLE
feat: replace `address` and `port` with URL for RPC CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,6 +4154,7 @@ dependencies = [
  "clap 3.2.18",
  "cli-common",
  "git2",
+ "http",
  "jaq-core",
  "logger",
  "markup-converter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
  "log",
  "openssl-probe",
  "openssl-sys",
- "url 2.2.2",
+ "url 2.3.0",
 ]
 
 [[package]]
@@ -2700,7 +2700,7 @@ dependencies = [
  "sha1",
  "tokio",
  "tokio-util",
- "url 2.2.2",
+ "url 2.3.0",
 ]
 
 [[package]]
@@ -2817,7 +2817,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower-service",
- "url 2.2.2",
+ "url 2.3.0",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4082,13 +4082,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "22fe195a4f217c25b25cb5058ced57059824a678474874038dc88d211bf508d3"
 dependencies = [
  "form_urlencoded",
  "idna 0.2.3",
- "matches",
  "percent-encoding 2.1.0",
 ]
 
@@ -4165,6 +4164,7 @@ dependencies = [
  "tokio",
  "tracing",
  "trycmd",
+ "url 2.3.0",
  "wasmflow-collection-cli",
  "wasmflow-grpctar",
  "wasmflow-oci",
@@ -4604,7 +4604,7 @@ version = "0.10.0"
 dependencies = [
  "serde",
  "thiserror",
- "url 2.2.2",
+ "url 2.3.0",
  "wasmflow-macros",
 ]
 

--- a/crates/bins/wafl/Cargo.toml
+++ b/crates/bins/wafl/Cargo.toml
@@ -39,6 +39,7 @@ wasmflow-oci = { path = "../../wasmflow/wasmflow-oci" }
 anyhow = "1.0"
 markup-converter = "0.2"
 jaq-core = "0.7"
+url = "2.3.0"
 
 [dev-dependencies]
 trycmd = "0.13"

--- a/crates/bins/wafl/Cargo.toml
+++ b/crates/bins/wafl/Cargo.toml
@@ -27,6 +27,7 @@ async-recursion = "1.0"
 nkeys = "0.2"
 tracing = "0.1"
 clap = { version = "3.0", features = ["derive", "env"] }
+http = "0.2"
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/bins/wafl/src/commands/rpc.rs
+++ b/crates/bins/wafl/src/commands/rpc.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
+use url::Url;
 
 pub(crate) mod invoke;
 pub(crate) mod list;
@@ -23,13 +24,9 @@ pub(crate) enum SubCommands {
 
 #[derive(Debug, Clone, Args)]
 pub(crate) struct ConnectOptions {
-  /// RPC port.
-  #[clap(short, long, env = wasmflow_collection_cli::options::env::WAFL_RPC_PORT,action)]
-  pub(crate) port: u16,
-
-  /// RPC address.
-  #[clap(short, long, default_value = "127.0.0.1", env = wasmflow_collection_cli::options::env::WAFL_RPC_ADDRESS,action)]
-  pub(crate) address: String,
+  /// RPC Url
+  #[clap(short, long)]
+  pub(crate) url: Url,
 
   /// Path to pem file for TLS connections.
   #[clap(long, action)]
@@ -46,4 +43,14 @@ pub(crate) struct ConnectOptions {
   /// The domain to verify against the certificate.
   #[clap(long, action)]
   pub(crate) domain: Option<String>,
+}
+
+impl ConnectOptions {
+  pub(crate) fn host(&self) -> String {
+    self.url.host().unwrap().to_string()
+  }
+
+  pub(crate) fn port(&self) -> u16 {
+    self.url.port().unwrap()
+  }
 }

--- a/crates/bins/wafl/src/commands/rpc.rs
+++ b/crates/bins/wafl/src/commands/rpc.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::{Args, Subcommand};
-use url::Url;
+use http::Uri;
 
 pub(crate) mod invoke;
 pub(crate) mod list;
@@ -25,8 +25,8 @@ pub(crate) enum SubCommands {
 #[derive(Debug, Clone, Args)]
 pub(crate) struct ConnectOptions {
   /// RPC Url
-  #[clap(short, long)]
-  pub(crate) url: Url,
+  #[clap(short = 'u', long = "url")]
+  pub(crate) uri: Uri,
 
   /// Path to pem file for TLS connections.
   #[clap(long, action)]
@@ -43,14 +43,4 @@ pub(crate) struct ConnectOptions {
   /// The domain to verify against the certificate.
   #[clap(long, action)]
   pub(crate) domain: Option<String>,
-}
-
-impl ConnectOptions {
-  pub(crate) fn host(&self) -> String {
-    self.url.host().unwrap().to_string()
-  }
-
-  pub(crate) fn port(&self) -> u16 {
-    self.url.port().unwrap()
-  }
 }

--- a/crates/bins/wafl/src/commands/rpc/invoke.rs
+++ b/crates/bins/wafl/src/commands/rpc/invoke.rs
@@ -53,7 +53,7 @@ pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
 
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
+    opts.connection.uri,
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/bins/wafl/src/commands/rpc/invoke.rs
+++ b/crates/bins/wafl/src/commands/rpc/invoke.rs
@@ -53,7 +53,7 @@ pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
 
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.address, opts.connection.port),
+    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/bins/wafl/src/commands/rpc/list.rs
+++ b/crates/bins/wafl/src/commands/rpc/list.rs
@@ -14,7 +14,7 @@ pub(crate) struct Options {
 pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.address, opts.connection.port),
+    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/bins/wafl/src/commands/rpc/list.rs
+++ b/crates/bins/wafl/src/commands/rpc/list.rs
@@ -14,7 +14,7 @@ pub(crate) struct Options {
 pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
+    opts.connection.uri,
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/bins/wafl/src/commands/rpc/stats.rs
+++ b/crates/bins/wafl/src/commands/rpc/stats.rs
@@ -16,7 +16,7 @@ pub(crate) struct Options {
 pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
+    opts.connection.uri,
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/bins/wafl/src/commands/rpc/stats.rs
+++ b/crates/bins/wafl/src/commands/rpc/stats.rs
@@ -16,7 +16,7 @@ pub(crate) struct Options {
 pub(crate) async fn handle(opts: Options) -> Result<()> {
   let _guard = crate::utils::init_logger(&opts.logging)?;
   let mut client = wasmflow_rpc::make_rpc_client(
-    format!("http://{}:{}", opts.connection.address, opts.connection.port),
+    format!("http://{}:{}", opts.connection.host(), opts.connection.port()),
     opts.connection.pem,
     opts.connection.key,
     opts.connection.ca,

--- a/crates/wasmflow/wasmflow-rpc/src/client.rs
+++ b/crates/wasmflow/wasmflow-rpc/src/client.rs
@@ -14,17 +14,13 @@ use crate::rpc::invocation_service_client::InvocationServiceClient;
 use crate::rpc::{ListRequest, StatsRequest, StatsResponse};
 
 /// Create an RPC client form common configuration
-pub async fn make_rpc_client<T: TryInto<Uri> + Send>(
-  address: T,
+pub async fn make_rpc_client(
+  uri: Uri,
   pem: Option<PathBuf>,
   key: Option<PathBuf>,
   ca: Option<PathBuf>,
   domain: Option<String>,
 ) -> Result<RpcClient, RpcClientError> {
-  let uri: Uri = address
-    .try_into()
-    .map_err(|_| RpcClientError::Other("Could not parse URI".to_owned()))?;
-
   let mut builder = Channel::builder(uri);
 
   if let (Some(pem), Some(key)) = (pem, key) {


### PR DESCRIPTION
Replaces current `address` and `port` options from the RPC option from`wafl`
CLI with a single URL to use a connection string.

Fixes: https://github.com/wasmflow/wasmflow/issues/67